### PR TITLE
Change ConfigMap generation to using toPrettyJson instead of manually parsing the yaml to json

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.1.0"
-version: 1.1.0
+version: 1.1.1
 name: cloudflare-ddns
 description: Dynamic DNS service based on Cloudflare! Access your home network remotely via a custom domain name without a static IP!
 home: https://github.com/nickvdyck/cloudflare-ddns

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.config.apiToken -}}
+{{- fail "Please set the API Token with the secrets.apiToken and not with config.apiToken value." -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,17 +13,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   config.json: |
-    {
-      "ipv4": {{ .Values.config.ipv4}},
-      "ipv6": {{ .Values.config.ipv6}},
-      "records": [
-        {{- range $record := $.Values.config.records }}
-          {
-            "zoneId": "{{ $record.zoneId }}",
-            "subdomain": "{{ $record.subdomain }}",
-            "proxied": {{ $record.proxied }}
-          }
-        {{- end }}
-      ]
-    }
-
+    {{- .Values.config | toPrettyJson | nindent 4 }}


### PR DESCRIPTION
When using multiple records with the helm chart an invalid json is generated in these lines:

https://github.com/vandycknick/cloudflare-ddns/blob/230f9a60c300ae28d7a5f498ac9b7be85d6fbf46/chart/templates/configmap.yaml#L16-L23
This is because there is a comma missing between each array entry.

I would propose using the helm function `toJson` or `toPrettyJson` to generate the json in the ConfigMap. That way you don't have to parse the values file and generate a json file in the helm chart but only need to correctly parse the json config in the ddns application itself. I also added a check that fails the helm install if the value `config.apiKey` is set with a warning that `secrets.apiKey` should be used instead. What do you think of this change?